### PR TITLE
feat(wip): add oversea server enums

### DIFF
--- a/src/background/main.ts
+++ b/src/background/main.ts
@@ -3,7 +3,7 @@ import { onMessage } from 'webext-bridge'
 import { cookies, storage, alarms } from 'webextension-polyfill'
 import { md5, randomIntFromInterval } from '~/utils.js'
 
-const SERVER_LIST = ['cn_gf01', 'cn_qd01']
+const SERVER_LIST = ['cn_gf01', 'cn_qd01', 'os_usa', 'os_euro', 'os_asia', 'os_cht']
 // 一分钟
 const INTERVAL_TIME = 1
 

--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -2,7 +2,7 @@
 import { sendMessage } from 'webext-bridge'
 import { getTime, getClock } from '~/utils.js'
 
-const SERVER_LIST = ['官服', 'B服']
+const SERVER_LIST = ['天空岛', '世界树', 'NA', 'EU', 'Asia', 'SAR']
 
 interface userDataType {
   current_resin: number


### PR DESCRIPTION
This PR tries to add support for Genshin Impact global servers, namely: NA, EU, Asia, and SAR servers:

- [x] Append server enums to `SERVER_LIST`
- [ ] Change API root based on server. For global servers, the URL should be:

  ```diff
  - https://api-takumi-record.mihoyo.com/game_record/app/genshin/api/dailyNote
  + https://bbs-api-os.hoyolab.com/game_record/app/genshin/api/dailyNote
  ```

- [ ] Change the `salt` used in creating `DS`. For global servers:

  ```diff
  - salt=xV8v4Qu54lUKrEYFZkJhB8cuOh9Asafs
  + salt=okr4obncj8bw5a65hbnn5oo6ixjc3l9w
  ```

I've added the enums but have not yet addressed the latter two modifications. Let me know if you are willing to add these changes (and in what manner) ;)